### PR TITLE
Changed form of dict creation to work under Python 2.6

### DIFF
--- a/test/test_util.py
+++ b/test/test_util.py
@@ -31,10 +31,10 @@ def mocked_requests(mocked_urls):
             if isinstance(mocked_urls, basestring):
                 url_files = open_files.values()[0]
             else:
-                url_files = {
-                    url: open_files.get(file_path)
+                url_files = dict([
+                    (url, open_files.get(file_path))
                     for url, file_path in mocked_urls.iteritems()
-                }
+                ])
             side_effect = _mock_request_side_effect(url_files)
 
             with mock.patch('requests.get', side_effect=side_effect):

--- a/ulmo/ncdc/ghcn_daily/core.py
+++ b/ulmo/ncdc/ghcn_daily/core.py
@@ -112,10 +112,10 @@ def get_data(station_id, elements=None, update=True, as_dataframe=False):
     if as_dataframe:
         return dataframes
     else:
-        return {
-            key: util.dict_from_dataframe(dataframe)
+        return dict([
+            (key, util.dict_from_dataframe(dataframe))
             for key, dataframe in dataframes.iteritems()
-        }
+        ])
 
 
 def get_stations(country=None, state=None, elements=None, start_year=None,
@@ -247,11 +247,11 @@ def _get_inventory(update=True):
 def _parse_fwf(file_path, columns, na_values=None):
     colspecs = [(start, end) for name, start, end, converter in columns]
     names = [name for name, start, end, converter in columns]
-    converters = {
-        name: converter
+    converters = dict([
+        (name, converter)
         for name, start, end, converter in columns
         if not converter is None
-    }
+    ])
 
     return pandas.io.parsers.read_fwf(file_path,
         colspecs=colspecs, header=None, na_values=na_values, names=names,

--- a/ulmo/ncdc/gsod/core.py
+++ b/ulmo/ncdc/gsod/core.py
@@ -62,7 +62,7 @@ def get_data(station_codes, start_date=None, end_date=None, parameters=None):
     # note: opening tar files and parsing the headers and such is a relatively
     # lengthy operation so you don't want to do it too often, hence try to
     # grab all stations at the same time per tarfile
-    data_dict = {station_code: None for station_code in station_codes}
+    data_dict = dict([(station_code, None) for station_code in station_codes])
 
     for year in range(start_date.year, end_date.year + 1):
         tar_path = _get_gsod_file(year)
@@ -123,10 +123,10 @@ def get_stations(update=True):
 
     with open(NCDC_GSOD_STATIONS_FILE, 'rb') as f:
         reader = csv.DictReader(f)
-        stations = {
-            _station_code(row): _process_station(row)
+        stations = dict([
+            (_station_code(row), _process_station(row))
             for row in reader
-        }
+        ])
     return stations
 
 
@@ -239,7 +239,8 @@ def _read_gsod_file(gsod_tar, station, year):
 def _record_array_to_value_dicts(record_array):
     names = record_array.dtype.names
     value_dicts = [
-        {name: value[name_index] for name_index, name in enumerate(names)}
+        dict([(name, value[name_index])
+                for name_index, name in enumerate(names)])
         for value in record_array]
     return value_dicts
 

--- a/ulmo/ncdc/gsod/pytables.py
+++ b/ulmo/ncdc/gsod/pytables.py
@@ -47,11 +47,11 @@ def update_data(station_codes=None, start_year=None, end_year=None, path=None):
 
     all_stations = get_stations()
     if station_codes:
-        stations = {
-                station_code: all_stations.get(station_code)
+        stations = dict([
+                (station_code, all_stations.get(station_code))
                 for station_code in station_codes
                 if station_code in all_stations
-        }
+        ])
     else:
         stations = all_stations
 

--- a/ulmo/waterml/common.py
+++ b/ulmo/waterml/common.py
@@ -40,10 +40,10 @@ def parse_site_values(content_io, namespace, query_isodate=None):
                     for element in values_element.findall(namespace + tag)
                 ]
                 if len(collection):
-                    collection_dict = {
-                        item[key]: item
+                    collection_dict = dict([
+                        (item[key], item)
                         for item in collection
-                    }
+                    ])
                     data_dict[code][collection_name] = collection_dict
 
             if query_isodate:
@@ -103,10 +103,10 @@ def parse_variables(content_io, namespace):
         _parse_variable(variable_element, namespace)
         for variable_element in variable_elements
     ]
-    variables = {
-        variable_dict['code']: variable_dict
+    variables = dict([
+        (variable_dict['code'], variable_dict)
         for variable_dict in variable_dicts
-    }
+    ])
     return variables
 
 
@@ -132,12 +132,12 @@ def _element_dict(element, exclude_children=None, prepend_attributes=True):
     if len(element) == 0 and not element.text is None:
         element_dict[element_name] = element.text
 
-    element_dict.update({
-        _element_dict_attribute_name(key, element_name,
-            prepend_element_name=prepend_attributes): value
+    element_dict.update(dict([
+        (_element_dict_attribute_name(key, element_name,
+            prepend_element_name=prepend_attributes), value)
         for key, value in element.attrib.iteritems()
         if value.split(':')[0] not in ['xsd', 'xsi']
-    })
+    ]))
 
     for child in element.iterchildren():
         if not child.tag.split('}')[-1] in exclude_children:
@@ -261,18 +261,20 @@ def _parse_site_info(site_info, namespace):
         return_dict['elevation_m'] = elevation_m.text
 
     # WaterML 1.0 notes
-    notes = {
-        util.camel_to_underscore(note.attrib['title'].replace(' ', '')): note.text
+    notes = dict([
+        (util.camel_to_underscore(note.attrib['title'].replace(' ', '')),
+            note.text)
         for note in site_info.findall(namespace + 'note')
-    }
+    ])
     if notes:
         return_dict['notes'] = notes
 
     # WaterML 1.1 siteProperties
-    site_properties = {
-        util.camel_to_underscore(site_property.attrib['name'].replace(' ', '')): site_property.text
+    site_properties = dict([
+        (util.camel_to_underscore(site_property.attrib['name'].replace(' ',
+            '')), site_property.text)
         for site_property in site_info.findall(namespace + 'site_property')
-    }
+    ])
     if site_properties:
         return_dict['site_properties'] = site_properties
 
@@ -422,7 +424,7 @@ def _parse_variable(variable_element, namespace):
 
 def _scrub_prefix(element_dict, prefix):
     "returns a dict with prefix scrubbed from the keys"
-    return {
-        k.split(prefix + '_')[-1]: v
+    return dict([
+        (k.split(prefix + '_')[-1], v)
         for k, v in element_dict.items()
-    }
+    ])

--- a/ulmo/wof/core.py
+++ b/ulmo/wof/core.py
@@ -45,10 +45,9 @@ def get_sites(wsdl_url):
         response_buffer = StringIO.StringIO(response.encode('ascii', 'ignore'))
         sites = waterml.v1_1.parse_site_infos(response_buffer)
 
-    return {
-        site['network'] + ':' + site['code']: site
-        for site in sites.values()
-    }
+    return dict([ (site['network'] + ':' + site['code'], site)
+                  for site in sites.values()
+                ])
 
 
 def get_site_info(wsdl_url, site_code):
@@ -87,10 +86,11 @@ def get_site_info(wsdl_url, site_code):
     if len(sites) == 0:
         return {}
     site_info = sites.values()[0]
-    series_dict = {
-        series['variable']['vocabulary'] + ':' + series['variable']['code']: series
+    series_dict = dict([
+        (series['variable']['vocabulary'] + ':' + series['variable']['code'],
+            series)
         for series in site_info['series']
-    }
+    ])
     site_info['series'] = series_dict
     return site_info
 
@@ -174,10 +174,10 @@ def get_variable_info(wsdl_url, variable_code=None):
     if not variable_code is None and len(variable_info) == 1:
         return variable_info.values()[0]
     else:
-        return {
-            '%s:%s' % (var['vocabulary'], var['code']): var
+        return dict([
+            ('%s:%s' % (var['vocabulary'], var['code']), var)
             for var in variable_info.values()
-        }
+        ])
 
 
 def _waterml_version(suds_client):


### PR DESCRIPTION
This form of dict creation wasn't working for me anyway with Python 2.6.  Does work with Python 2.7.

```
a = {key:var for key,var in [('one', 1), ('two', 2)]}
```

Shifted to a different stye that work under 2.6.

```
a = dict((key,var) for key,var in [('one', 1), ('two', 2)])
```

Kindest regards,
Tim
