### PR TITLE
Fix incorrect pytables dependency version: 0.2.3 -> 2.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'suds>=0.4',
     ],
     extras_require={
-        'pytables_caching': ['tables>=0.2.3']
+        'pytables_caching': ['tables>=2.3.0']
     },
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Rich caught this when setting up the binstar packages
