### PR TITLE
cuahsi/wof enhancements

### DIFF
--- a/ulmo/cuahsi/wof/core.py
+++ b/ulmo/cuahsi/wof/core.py
@@ -284,7 +284,7 @@ def _get_client(wsdl_url, cache_duration=("default",)):
             cache = _suds_client.options.cache
             # could add some error catching ...
             if cache_duration[0] == "default":
-                cache.setduration(days, 1)
+                cache.setduration(days=1)
             else:
                 cache.setduration(**dict([cache_duration]))
 


### PR DESCRIPTION
Addressed Issue #64 (very simple change). Also Issue #94 : Upgraded cuahsi/wof services to re-use a suds client instance if already opened, and allow an optional suds cache argument. Did some testing (issued WOF requests) to make sure wof requests worked w/o the new suds_cache argument (ie, use default; same API behavior as before), as well as with suds_cache=None. Did not check the actual cache behavior on local /tmp directory.
