### PR TITLE
Fixed site_type assignment to use url_params, not url_param

### DIFF
--- a/ulmo/usgs/nwis/core.py
+++ b/ulmo/usgs/nwis/core.py
@@ -130,7 +130,7 @@ def get_sites(sites=None, state_code=None, huc=None, bounding_box=None,
             url_params['countyCd'] = _as_str(county_code)
 
         if site_type:
-            url_param['siteType'] = _as_str(site_type)
+            url_params['siteType'] = _as_str(site_type)
 
         if parameter_code:
             url_params['parameterCd'] = _as_str(parameter_code)


### PR DESCRIPTION
Was getting this error when issuing an usgs.nwis.get_sites request with a site_type argument:
```
/usr/anaconda/anaconda/envs/uwapl_em_4/lib/python2.7/site-packages/ulmo/usgs/nwis/core.pyc in 
get_sites(sites, state_code, huc, bounding_box, county_code, parameter_code, site_type, service, input_file, **kwargs)
    131 
    132         if site_type:
--> 133             url_param['siteType'] = _as_str(site_type)
    134 
    135         if parameter_code:

NameError: global name 'url_param' is not defined
```
Tracked it down to that mispelling. All other options use `url_params`. **WARNING**: I didn't test this fix! Just thought I'd contribute back while I was paying attention.