### PR TITLE
Added MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,8 @@
+include AUTHORS
+include CHANGES
+include INSTALL
+include LICENSE
+include *.rst
+include *.txt
+
+recursive-include ulmo *.py


### PR DESCRIPTION
The source dist for `ulmo-0.8.0.tar.gz` at PyPI seems to be broken.  I added a `MANIFEST.in` and that will probably fix it.

```
> pip install ulmo-0.8.0.tar.gz
Processing ./ulmo-0.8.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/tmp/pip-NYwRgB-build/setup.py", line 39, in <module>
        __version__ = version()
      File "/tmp/pip-NYwRgB-build/setup.py", line 34, in version
        with open(os.path.join(rootpath, "VERSION.txt")) as v:
    IOError: [Errno 2] No such file or directory: '/tmp/pip-NYwRgB-build/VERSION.txt'
```