### PR TITLE
Date filtering when getting data out of hdf5 files

### DIFF
--- a/test/usgs_nwis_hdf5_test.py
+++ b/test/usgs_nwis_hdf5_test.py
@@ -1,6 +1,7 @@
 from builtins import range
 import os
 import shutil
+import datetime
 
 import freezegun
 import pandas
@@ -369,6 +370,33 @@ def test_site_data_filter_by_multiple_parameter_codes(test_file_path):
     for code in parameter_code:
         if code in list(site_data.keys()):
             assert site_data[code] == all_site_data[code]
+
+
+def test_site_data_filter_by_date_all_param(test_file_path):
+    site_code = '08068500'
+    parameter_code = '00065:00003'
+    date_str = '2000-01-01'
+    site_data_file = test_util.get_test_file_path(
+        'usgs/nwis/site_%s_daily.xml' % site_code)
+    nwis.hdf5.update_site_data(site_code, path=test_file_path,
+            input_file=site_data_file, autorepack=False)
+    site_data = nwis.hdf5.get_site_data(site_code, path=test_file_path, start=date_str)
+    for par, data in site_data.iteritems():
+        first_value = data['values'][0]
+        assert datetime.datetime.strptime(first_value["datetime"], '%Y-%m-%dT%H:%M:%S') >= datetime.datetime.strptime(date_str, '%Y-%m-%d')
+
+
+def test_site_data_filter_by_date_single_param(test_file_path):
+    site_code = '08068500'
+    parameter_code = '00065:00003'
+    date_str = '2000-01-01'
+    site_data_file = test_util.get_test_file_path(
+        'usgs/nwis/site_%s_daily.xml' % site_code)
+    nwis.hdf5.update_site_data(site_code, path=test_file_path,
+            input_file=site_data_file, autorepack=False)
+    site_data = nwis.hdf5.get_site_data(site_code, path=test_file_path, start=date_str)
+    first_value = site_data[parameter_code]['values'][0]
+    assert datetime.datetime.strptime(first_value["datetime"], '%Y-%m-%dT%H:%M:%S') >= datetime.datetime.strptime(date_str, '%Y-%m-%d')
 
 
 def test_site_data_update_site_list_with_multiple_updates(test_file_path):

--- a/test/usgs_nwis_hdf5_test.py
+++ b/test/usgs_nwis_hdf5_test.py
@@ -381,7 +381,7 @@ def test_site_data_filter_by_date_all_param(test_file_path):
     nwis.hdf5.update_site_data(site_code, path=test_file_path,
             input_file=site_data_file, autorepack=False)
     site_data = nwis.hdf5.get_site_data(site_code, path=test_file_path, start=date_str)
-    for par, data in site_data.iteritems():
+    for par, data in site_data.items():
         first_value = data['values'][0]
         assert datetime.datetime.strptime(first_value["datetime"], '%Y-%m-%dT%H:%M:%S') >= datetime.datetime.strptime(date_str, '%Y-%m-%d')
 

--- a/ulmo/usgs/nwis/hdf5.py
+++ b/ulmo/usgs/nwis/hdf5.py
@@ -126,7 +126,7 @@ def get_site(site_code, path=None, complevel=None, complib=None):
 
 
 def get_site_data(site_code, agency_code=None, parameter_code=None, path=None,
-                  complevel=None, complib=None):
+                  complevel=None, complib=None, start=None):
     """Fetches previously-cached site data from an hdf5 file.
 
     Parameters
@@ -154,6 +154,8 @@ def get_site_data(site_code, agency_code=None, parameter_code=None, path=None,
         the best available compression library available on your system will be
         selected. If complevel argument is set to 0 then no compression will be
         used.
+    start: ``None`` or string formatted date like 2014-01-01
+        Filter the dataset to return only data later that the start date
 
 
     Returns
@@ -173,14 +175,14 @@ def get_site_data(site_code, agency_code=None, parameter_code=None, path=None,
         if parameter_code:
             site_data = dict([
                 (variable_group._v_pathname.rsplit('/', 1)[-1],
-                 _variable_group_to_dict(store, variable_group))
+                 _variable_group_to_dict(store, variable_group, start=start))
                 for variable_group in site_group
                 if variable_group._v_pathname.rsplit('/', 1)[-1] in parameter_code
             ])
         else:
             site_data = dict([
                 (variable_group._v_pathname.rsplit('/', 1)[-1],
-                 _variable_group_to_dict(store, variable_group))
+                 _variable_group_to_dict(store, variable_group, start=start))
                 for variable_group in site_group
             ])
     return site_data
@@ -622,7 +624,7 @@ def _values_df_to_dicts(values_df):
     return dicts
 
 
-def _variable_group_to_dict(store, variable_group):
+def _variable_group_to_dict(store, variable_group, start=None):
     _v_attrs = variable_group._v_attrs
     variable_dict = dict([
         (key, getattr(_v_attrs, key))
@@ -630,6 +632,8 @@ def _variable_group_to_dict(store, variable_group):
     ])
     values_path = variable_group._v_pathname + '/values'
     values_df = store[values_path]
+    if start:
+        values_df = values_df[values_df.index > start]
     variable_dict['values'] = _values_df_to_dicts(values_df)
 
     return variable_dict


### PR DESCRIPTION
Previously there was no way to filter data before getting it out of the hdf5 files. For some of the sites we have, there is 50-60 years with of data, and the conversion from the Pandas DataFrame to a python list of dicts was slow ( python loop over 300k rows). This adds a "start" parameter to nwis.hdf5.get_site_data() to allow for some filtering before that conversion takes place. 

Longer term, with PyTables, you can do out of memory slicing from a HDF5 file, which might be something to look into. 