### PR TITLE
move cache file from tmp to cache folder instead of copy

### DIFF
--- a/ulmo/usgs/nwis/hdf5.py
+++ b/ulmo/usgs/nwis/hdf5.py
@@ -275,7 +275,7 @@ def repack(path, complevel=None, complib=None):
 
     temp_path = tempfile.NamedTemporaryFile().name
     _ptrepack(path, temp_path, **comp_kwargs)
-    shutil.copyfile(temp_path, path)
+    shutil.move(temp_path, path)
 
 
 def update_site_list(sites=None, state_code=None, huc=None, bounding_box=None, 


### PR DESCRIPTION
when we do frequent updates of data for all gauges, we end up writing several of the temp hdf5 cache files in /tmp and that fills up disk space so moving them to the ulmo cache directory instead of copying.