### PR TITLE
fix bug  mosaic not working in USGS.core.get_raster(mosaic=True)

### DIFF
--- a/ulmo/usgs/ned/core.py
+++ b/ulmo/usgs/ned/core.py
@@ -138,6 +138,7 @@ def get_raster(layer, bbox, path=None, check_modified=False, mosaic=False):
             path = os.path.join(util.get_ulmo_dir(), DEFAULT_FILE_PATH)
 
         util.mkdir_if_doesnt_exist(os.path.join(path, 'by_boundingbox'))
+        xmin, ymin, xmax, ymax = [float(n) for n in bbox]
         uid = util.generate_raster_uid(layer, xmin, ymin, xmax, ymax)
         output_path = os.path.join(path, 'by_boundingbox', uid + '.tif')
 


### PR DESCRIPTION
bbox conversion to xmin, ymin, xmax, ymax not included
in function.