### PR TITLE
update deprecated diff method

### DIFF
--- a/ulmo/cpc/drought/core.py
+++ b/ulmo/cpc/drought/core.py
@@ -151,7 +151,7 @@ def get_data(state=None, climate_division=None, start=None, end=None,
         else:
             # some data are duplicated (e.g. final data from 2011 stretches into
             # prelim data of 2012), so just take those that are new
-            append_index = year_data.index - data.index
+            append_index = year_data.index.difference(data.index)
             if len(append_index):
                 data = data.append(year_data.ix[append_index])
 


### PR DESCRIPTION
A small pandas related fix for `ulmo.cpc.core` to get set diff methods on df indexes to work in pandas > 0.19. 
This build has uncovered a couple of pandas related test failures  (since we are not pinning it to a specific version and some breaking changes were introduced in pandas versions after last build few months ago). i will make those api changes later this week and submit a new PR.