### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 
 from setuptools import setup, find_packages

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,37 @@ def version():
 __version__ = version()
 
 
-with open('requirements.txt') as f:
-    required = f.read().splitlines()
+def parse_requirement(requirement, excludes):
+    lib = requirement.strip().split('#')[0]  # strip new lines and comments
+    if lib:
+        lib_name = re.split(r'[[<>=! ]+', lib)[0]
+        if lib_name in excludes:
+            return ''
+        return lib.strip()
+    return ''
+
+
+def load_requirements(excludes=None):
+    if excludes is None:
+      excludes = []
+    requirements = []
+    with open('requirements.txt') as requirements_file:
+        line = requirements_file.readline()
+        while line:
+            line = line.strip()
+            while line.endswith('\\'):
+                line += requirements_file.readline().strip()
+            line = ' '.join(line.split('\\'))
+            requirement = parse_requirement(line, excludes)
+            if requirement:
+                requirements.append(requirement)
+            line = requirements_file.readline()
+    return requirements
+
+
+excludes = ['pytest']
+required = load_requirements(excludes)
+
 
 setup(
     name='ulmo',


### PR DESCRIPTION
Parse a requirements.txt file with pinned versions.  IMO, a better practice is to add the requirements directly to setup.py, but when using a requirements.txt file this change should parse it properly.