### PR TITLE
fix for issue 159. ncdc ghcn_daily.get_data failed with error

### DIFF
--- a/ulmo/ncdc/ghcn_daily/core.py
+++ b/ulmo/ncdc/ghcn_daily/core.py
@@ -92,7 +92,9 @@ def get_data(station_id, elements=None, update=True, as_dataframe=False):
 
         # here we're just using pandas' builtin resample logic to construct a daily
         # index for the timespan
-        daily_index = element_df.resample('D').index.copy()
+        # 2018/11/27 johanneshorak: hotfix to get ncdc ghcn_daily working again
+        # new resample syntax requires resample method to generate resampled index.
+        daily_index = element_df.resample('D').sum().index.copy()
 
         # XXX: hackish; pandas support for this sort of thing will probably be
         # added soon


### PR DESCRIPTION
First time pull request ever. This is a fix(?) to [issue 159](https://github.com/ulmo-dev/ulmo/issues/159).

The method `ncdc.ghcn_daily.get_data()` failed due to changes in how resampling is handled by pandas. There are different ways to fix this issue, the quickest seemed to just supply how the timeseries should be resampled, leading to the actual generation of the resampled index - which is all that is needed to get the code working again.
