### PR TITLE
Overhaul sphinx docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,20 @@
 # ignore egginfo file
 ulmo.egg-info/
 
-# ignore build, dist dir
+# ignore build, dist, ulmo_test_cache, .pytest_cache dir
 dist/
 build/
+ulmo_test_cache/
+.pytest_cache/
 
 # ignore sphinx build dir
 docs/_build/
 
 # ignore compiled python files
 *.pyc
+
+# ignore .coverage
+.coverage
 
 # Ignore checkpoints created (especially for the examples)
 .ipynb_checkpoints

--- a/INSTALL
+++ b/INSTALL
@@ -25,7 +25,7 @@ code`_ and run setup.py from the root directory:
 
 To setup a development environment using conda:
 
-    conda env create -n myenv --file py2_conda_environment.yml #(or py3_conda_environment.yml if you want to work with python 3)
+    conda env create -n myenv --file conda_environment.yml
 
     source activate myenv #(use 'activate test_environment' on windows)
 

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -1,6 +1,7 @@
 # conda environment file for python 3, includes packages needed for testing
+# and building the sphinx docs
 # create a conda virtual env using:
-#   conda env create -n myenv --file py3_conda_environment.yml
+#   conda env create -n myenv --file conda_environment.yml
 #   source activate myenv (use 'activate myenv' on windows)
 #   python setup.py develop
 #
@@ -15,6 +16,7 @@ channels:
 
 dependencies:
     - python>=3.4
+    - pip
     - appdirs
     - beautifulsoup4
     - future
@@ -30,6 +32,11 @@ dependencies:
     - suds-jurko
     - freezegun
     - html5lib<=0.9999999
+    
+    # Specifically for building Sphinx docs
+    - numpydoc>=0.4
+    - python-dateutil
+    - sphinx>=1.1.3
 
     # test dependencies
     - pytest-runner

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,6 +1,23 @@
 .. _api:
 
 
+ulmo Readers
+============
+
+ulmo readers / api's.
+
+
+.. _dates-and-times:
+
+note on dates and times
+-----------------------
+
+Dates and times can provided a few different ways, depending on what is
+convenient. They can either be a string representation or as instances of date
+and datetime objects from python's datetime standard library module.  For
+strings, the ISO 8061 format ('YYYY-mm-dd HH:MM:SS' or some abbreviated version)
+is accepted, as well dates in 'mm/dd/YYYY' format.
+
 
 California Department of Water Resources Historical Data
 ========================================================
@@ -8,53 +25,65 @@ California Department of Water Resources Historical Data
    :members: get_stations, get_sensors, get_station_sensors, get_data
 
 
-Climate Prediction Center Weekly Drought
-========================================
+Climate Prediction Center (CPC) Weekly Drought
+==============================================
 .. automodule:: ulmo.cpc.drought
    :members: get_data
 
 
-CUAHSI WaterOneFlow
-===================
+CUAHSI Hydrologic Information System (HIS)
+==========================================
+
+CUAHSI HIS Central
+------------------
 .. automodule:: ulmo.cuahsi.his_central
    :members: get_services
 
+
+CUAHSI WaterOneFlow
+-------------------
 .. automodule:: ulmo.cuahsi.wof
    :members: get_sites, get_site_info, get_values, get_variable_info
 
 
-Lower Colorado River Authority (LCRA) Hydromet Data
-===================================================
+Lower Colorado River Authority (LCRA)
+=====================================
+
+LCRA Hydromet Data
+------------------
 .. automodule:: ulmo.lcra.hydromet
    :members: get_sites_by_type, get_site_data, get_all_sites, get_current_data
 
 
-Lower Colorado River Authority (LCRA) Water Quality Data
-========================================================
+LCRA Water Quality Data
+-----------------------
 .. automodule:: ulmo.lcra.waterquality
    :members: get_sites, get_historical_data, get_recent_data, get_site_info
 
 
 NASA ORNL Daymet weather data services
-========================================================
+======================================
 .. automodule:: ulmo.nasa.daymet
    :members: get_variables, get_daymet_singlepixel
    
 
-National Climatic Data Center Climate Index Reference Sequential (CIRS)
-=======================================================================
+National Climatic Data Center (NCDC)
+====================================
+
+NCDC Climate Index Reference Sequential (CIRS)
+-----------------------------------------------
 .. automodule:: ulmo.ncdc.cirs
    :members: get_data
 
 
-National Climatic Data Center Global Historical Climate Network Daily
-=====================================================================
+NCDC Global Historical Climate Network (GHCN) Daily
+---------------------------------------------------
 .. automodule:: ulmo.ncdc.ghcn_daily
    :members: get_data, get_stations
 
 
-National Climatic Data Center Global Summary of the Day
-=======================================================
+NCDC Global Summary of the Day (GSoD)
+-------------------------------------
 .. automodule:: ulmo.ncdc.gsod
    :members: get_data, get_stations
 
@@ -71,8 +100,8 @@ US Army Corps of Engineers - Tulsa District Water Control
    :members: get_stations, get_station_data
 
 
-USGS National Water Information System
-======================================
+USGS National Water Information System (NWIS)
+=============================================
 .. automodule:: ulmo.usgs.nwis
    :members: get_sites, get_site_data
 
@@ -80,31 +109,13 @@ USGS National Water Information System
    :members:
 
 
-USGS Emergency Data Distribution Network services
-=================================================
+USGS Emergency Data Distribution Network (EDDN) services
+========================================================
 .. automodule:: ulmo.usgs.eddn
    :members: get_data, decode
-
-
-USGS Earth Resources Observation Systems (EROS) services
-========================================================
-.. automodule:: ulmo.usgs.eros
-   :members: get_available_datasets, get_themes, get_attribute_list, get_available_formats, get_raster, get_raster_availability
 
 
 USGS National Elevation Dataset (NED) services
 ========================================================
 .. automodule:: ulmo.usgs.ned
    :members: get_available_layers, get_raster, get_raster_availability
-
-
-.. _dates-and-times:
-
-note on dates and times
------------------------
-
-Dates and times can provided a few different ways, depending on what is
-convenient. They can either be a string representation or as instances of date
-and datetime objects from python's datetime standard library module.  For
-strings, the ISO 8061 format ('YYYY-mm-dd HH:MM:SS' or some abbreviated version)
-is accepted, as well dates in 'mm/dd/YYYY' format.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,5 +1,4 @@
-.. _api:
-
+.. title:: ulmo readers (API)
 
 ulmo Readers
 ============
@@ -18,6 +17,8 @@ and datetime objects from python's datetime standard library module.  For
 strings, the ISO 8061 format ('YYYY-mm-dd HH:MM:SS' or some abbreviated version)
 is accepted, as well dates in 'mm/dd/YYYY' format.
 
+
+.. _api:
 
 California Department of Water Resources Historical Data
 ========================================================

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9,7 +9,7 @@ ulmo readers / api's.
 .. _dates-and-times:
 
 note on dates and times
------------------------
+=======================
 
 Dates and times can provided a few different ways, depending on what is
 convenient. They can either be a string representation or as instances of date
@@ -20,89 +20,53 @@ is accepted, as well dates in 'mm/dd/YYYY' format.
 
 .. _api:
 
-California Department of Water Resources Historical Data
-========================================================
-.. automodule:: ulmo.cdec.historical
-   :members: get_stations, get_sensors, get_station_sensors, get_data
 
+Readers for Global to USA-national data
+=======================================
 
 Climate Prediction Center (CPC) Weekly Drought
-==============================================
+----------------------------------------------
 .. automodule:: ulmo.cpc.drought
    :members: get_data
 
 
 CUAHSI Hydrologic Information System (HIS)
-==========================================
+------------------------------------------
 
-CUAHSI HIS Central
-------------------
 .. automodule:: ulmo.cuahsi.his_central
    :members: get_services
 
-
-CUAHSI WaterOneFlow
--------------------
 .. automodule:: ulmo.cuahsi.wof
    :members: get_sites, get_site_info, get_values, get_variable_info
 
 
-Lower Colorado River Authority (LCRA)
-=====================================
-
-LCRA Hydromet Data
-------------------
-.. automodule:: ulmo.lcra.hydromet
-   :members: get_sites_by_type, get_site_data, get_all_sites, get_current_data
-
-
-LCRA Water Quality Data
------------------------
-.. automodule:: ulmo.lcra.waterquality
-   :members: get_sites, get_historical_data, get_recent_data, get_site_info
-
-
 NASA ORNL Daymet weather data services
-======================================
+--------------------------------------
 .. automodule:: ulmo.nasa.daymet
    :members: get_variables, get_daymet_singlepixel
-   
+
 
 National Climatic Data Center (NCDC)
-====================================
+------------------------------------
 
 NCDC Climate Index Reference Sequential (CIRS)
------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. automodule:: ulmo.ncdc.cirs
    :members: get_data
 
-
 NCDC Global Historical Climate Network (GHCN) Daily
----------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. automodule:: ulmo.ncdc.ghcn_daily
    :members: get_data, get_stations
 
-
 NCDC Global Summary of the Day (GSoD)
--------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. automodule:: ulmo.ncdc.gsod
    :members: get_data, get_stations
 
 
-Texas Weather Connection Daily Keetch-Byram Drought Index (KBDI)
-================================================================
-.. automodule:: ulmo.twc.kbdi
-   :members: get_data
-
-
-US Army Corps of Engineers - Tulsa District Water Control
-=========================================================
-.. automodule:: ulmo.usace.swtwc
-   :members: get_stations, get_station_data
-
-
 USGS National Water Information System (NWIS)
-=============================================
+---------------------------------------------
 .. automodule:: ulmo.usgs.nwis
    :members: get_sites, get_site_data
 
@@ -111,12 +75,43 @@ USGS National Water Information System (NWIS)
 
 
 USGS Emergency Data Distribution Network (EDDN) services
-========================================================
+--------------------------------------------------------
 .. automodule:: ulmo.usgs.eddn
    :members: get_data, decode
 
 
-USGS National Elevation Dataset (NED) services
-========================================================
+USGS National Elevation Dataset (NED) raster services
+-----------------------------------------------------
 .. automodule:: ulmo.usgs.ned
    :members: get_available_layers, get_raster, get_raster_availability
+
+
+Readers for USA regional (sub-national) data
+============================================
+
+California Department of Water Resources Historical Data
+--------------------------------------------------------
+.. automodule:: ulmo.cdec.historical
+   :members: get_stations, get_sensors, get_station_sensors, get_data
+
+
+Lower Colorado River Authority (LCRA)
+-------------------------------------
+
+.. automodule:: ulmo.lcra.hydromet
+   :members: get_sites_by_type, get_site_data, get_all_sites, get_current_data
+
+.. automodule:: ulmo.lcra.waterquality
+   :members: get_sites, get_historical_data, get_recent_data, get_site_info
+
+
+Texas Weather Connection Daily Keetch-Byram Drought Index (KBDI)
+----------------------------------------------------------------
+.. automodule:: ulmo.twc.kbdi
+   :members: get_data
+
+
+US Army Corps of Engineers - Tulsa District Water Control
+---------------------------------------------------------
+.. automodule:: ulmo.usace.swtwc
+   :members: get_stations, get_station_data

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -222,4 +222,7 @@ latex_documents = [
 #latex_domain_indices = True
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3/', None),
+    'numpy': ('https://docs.scipy.org/doc/numpy', None),
+}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,7 +52,7 @@ API Reference
 Documentation for ulmo readers.
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 3
 
    api
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,8 +49,10 @@ repository. Bug reports, issues and especially pull Requests are welcome.
 API Reference
 -------------
 
+Documentation for ulmo readers.
+
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
    api
 

--- a/ulmo/cuahsi/his_central/__init__.py
+++ b/ulmo/cuahsi/his_central/__init__.py
@@ -1,8 +1,7 @@
 """
-    ulmo.cuahsi.his_central
-    ~~~~~~~~~~~~~~~~~~~~~~~
-
-    `CUAHSI HIS Central`_ web services
+    CUAHSI HIS Central
+    ~~~~~~~~~~~~~~~~~~
+    `CUAHSI HIS Central`_ catalog web services
 
     .. _CUAHSI HIS Central: http://his.cuahsi.org/hiscentral.html
 """

--- a/ulmo/cuahsi/wof/__init__.py
+++ b/ulmo/cuahsi/wof/__init__.py
@@ -1,8 +1,7 @@
 """
-    ulmo.cuahsi.wof
-    ~~~~~~~~~~~~~~~
-
-    `CUAHSI WaterOneFlow`_ web services
+    CUAHSI WaterOneFlow
+    ~~~~~~~~~~~~~~~~~~~
+    `CUAHSI WaterOneFlow`_ web data access services
 
     .. _CUAHSI WaterOneFlow: http://his.cuahsi.org/wofws.html
 """

--- a/ulmo/cuahsi/wof/core.py
+++ b/ulmo/cuahsi/wof/core.py
@@ -35,7 +35,7 @@ def get_sites(wsdl_url, suds_cache=("default",), timeout=None):
         URL of a service's web service definition language (WSDL) description.
         All WaterOneFlow services publish a WSDL description and this url is the
         entry point to the service.
-    suds_cache : ``None`` or tuple
+    suds_cache : `None` or tuple
         SOAP local cache duration for WSDL description and client object.
         Pass a cache duration tuple like ('days', 3) to set a custom duration.
         Duration may be in months, weeks, days, hours, or seconds.

--- a/ulmo/lcra/hydromet/__init__.py
+++ b/ulmo/lcra/hydromet/__init__.py
@@ -1,1 +1,11 @@
+"""
+    LCRA Hydromet Data
+    ~~~~~~~~~~~~~~~~~~
+    Access to hydrologic and climate data in the Colorado River Basin (Texas)
+    provided by the `Hydromet`_ web site and web service from
+    the `Lower Colorado River Authority`_.
+
+    .. _Lower Colorado River Authority: http://www.lcra.org
+    .. _Hydromet: http://hydromet.lcra.org
+"""
 from .core import get_sites_by_type, get_site_data, get_all_sites, get_current_data

--- a/ulmo/lcra/hydromet/core.py
+++ b/ulmo/lcra/hydromet/core.py
@@ -4,6 +4,7 @@
     This module provides access to hydrologic and climate data in the Colorado
     River Basin (Texas) provided by the `Lower Colorado River Authority`_
     `Hydromet`_ web site and web service.
+
     .. _Lower Colorado River Authority: http://www.lcra.org
     .. _Hydromet: http://hydromet.lcra.org
 """
@@ -51,11 +52,13 @@ dam_sites = ['1995', '1999', '2958', '2999', '3963', '3999']
 
 def get_sites_by_type(site_type):
     """Gets list of the hydromet site codes and description for site.
-    Parameters:
-    -----------
+
+    Parameters
+    ----------
     site_type : str
         In all but lake sites, this is the parameter code collected at the site.
         For lake sites, it is 'lake'. See ``site_types`` and ``PARAMETERS``
+
     Returns
     -------
     sites_dict: dict
@@ -64,7 +67,7 @@ def get_sites_by_type(site_type):
     sites_base_url = 'http://hydromet.lcra.org/navgagelist.asp?Stype=%s'
     # the url doesn't provide list of sites for the following parameters but
     # they are available with the paired parameter. e.g., flow is available
-    #at stage sites.
+    # at stage sites.
     if site_type == 'winddir':
         site_type = 'windsp'
     if site_type == 'flow':
@@ -100,6 +103,7 @@ def get_all_sites():
 def get_current_data(service, as_geojson=False):
     """fetches the current (near real-time) river stage and flow values from
     LCRA web service.
+
     Parameters
     ----------
     service : str
@@ -108,10 +112,11 @@ def get_current_data(service, as_geojson=False):
     as_geojson : 'True' or 'False' (default)
         If True the data is returned as geojson featurecollection and if False
         data is returned as list of dicts.
+
     Returns
     -------
-    current_values_dicts : a list of dicts or
-    current_values_geojson : a geojson featurecollection.
+        current_values_dicts : a list of dicts or
+        current_values_geojson : a geojson featurecollection.
     """
     request_body_template = (
         '<?xml version="1.0" encoding="utf-8"?>\n'
@@ -160,6 +165,7 @@ def get_current_data(service, as_geojson=False):
 def get_site_data(site_code, parameter_code, as_dataframe=True,
                   start_date=None, end_date=None, dam_site_location='head'):
     """Fetches site's parameter data
+
     Parameters
     ----------
     site_code : str
@@ -206,7 +212,7 @@ def get_site_data(site_code, parameter_code, as_dataframe=True,
             parameter_code = 'STAGE'
     elif parameter_code == 'RHUMID':
         parameter_code = 'Rhumid'
-    #the parameter selection dropdown doesn't have flow. the data comes with stage.
+    # the parameter selection dropdown doesn't have flow. the data comes with stage.
     elif parameter_code == 'FLOW':
         parameter_code = 'STAGE'
     else:
@@ -327,7 +333,7 @@ def _extract_headers_for_next_request(request):
         if tag_dict.get('value', None) == 'tabular':
             #
             continue
-        #some tags don't have a value and are used w/ JS to toggle a set of checkboxes
+        # some tags don't have a value and are used w/ JS to toggle a set of checkboxes
         payload[tag_dict['name']] = tag_dict.get('value')
     return payload
 
@@ -339,7 +345,7 @@ def _make_next_request(url, previous_request, data):
 
 
 def _parse_val(val):
-    #the &nsbp translates to the following unicode
+    # the &nsbp translates to the following unicode
     if val == u'\xa0':
         return None
     else:

--- a/ulmo/lcra/waterquality/__init__.py
+++ b/ulmo/lcra/waterquality/__init__.py
@@ -1,1 +1,11 @@
+"""
+    LCRA Water Quality Data
+    ~~~~~~~~~~~~~~~~~~~~~~~
+    Access to water quality data in the Colorado River Basin (Texas)
+    provided by the `Water Quality`_ web site and web service from
+    the `Lower Colorado River Authority`_.
+
+    .. _Lower Colorado River Authority: http://www.lcra.org
+    .. _Water Quality: http://waterquality.lcra.org/
+"""
 from .core import get_sites, get_historical_data, get_recent_data, get_site_info

--- a/ulmo/lcra/waterquality/core.py
+++ b/ulmo/lcra/waterquality/core.py
@@ -1,15 +1,16 @@
 """
     ulmo.lcra.waterquality.core
-    ~~~~~~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
     This module provides access to data provided by the `Lower Colorado 
     River Authority`_ `Water Quality`_ web site.
+
     .. _Lower Colorado River Authority: http://www.lcra.org
     .. _Water Quality: http://waterquality.lcra.org/
 """
 from bs4 import BeautifulSoup
 import logging
 from geojson import Point, Feature, FeatureCollection
-#import unicode
+# import unicode
 
 from ulmo import util
 
@@ -51,12 +52,14 @@ real_time_sites = {
 
 def get_sites(source_agency=None):
     """Fetches a list of sites with location and available metadata.
+
     Parameters
     ----------
-    source_agency : LCRA used code of the that collects the data. there
-    are sites whose sources are not listed so this filter may not return
-    all sites of a certain source. see
-    ``source_map``.
+    source_agency : str
+        LCRA used code of the that collects the data. There are sites whose
+        sources are not listed so this filter may not return all sites of a certain source.
+        See ``source_map``.
+
     Returns
     -------
     sites_geojson : geojson FeatureCollection
@@ -82,9 +85,10 @@ def get_sites(source_agency=None):
 
 def get_historical_data(site_code, start=None, end=None, as_dataframe=False):
     """Fetches data for a site at a given date.
+
     Parameters
     ----------
-    site_code: str
+    site_code : str
         The site code to fetch data for. A list of sites can be retrieved with
         ``get_sites()``
     date : ``None`` or date (see :ref:`dates-and-times`)
@@ -96,6 +100,7 @@ def get_historical_data(site_code, start=None, end=None, as_dataframe=False):
         to a dict of gauge variables and values. If ``True`` then the values
         dict will be a pandas.DataFrame object containing the equivalent
         information.
+
     Returns
     -------
     data_dict : dict
@@ -134,7 +139,7 @@ def get_historical_data(site_code, start=None, end=None, as_dataframe=False):
 
     headers = [head.text for head in gridview.findAll('th')]
 
-    #uses \xa0 for blank
+    # uses \xa0 for blank
 
     for row in gridview.findAll('tr'):
         vals = [_parse_val(aux.text) for aux in row.findAll('td')]
@@ -159,6 +164,7 @@ def get_historical_data(site_code, start=None, end=None, as_dataframe=False):
 def get_recent_data(site_code, as_dataframe=False):
     """fetches near real-time instantaneous water quality data for the LCRA
     bay sites.
+
     Parameters
     ----------
     site_code : str
@@ -167,9 +173,11 @@ def get_recent_data(site_code, as_dataframe=False):
         This determines what format values are returned as. If ``False``
         (default), the values will be list of value dicts. If ``True`` then 
         values are returned as pandas.DataFrame.
+
     Returns
     -------
-    list of values or dataframe.
+    list
+        list of values or dataframe.
     """
     if site_code not in real_time_sites.keys():
         log.info('%s is not in the list of LCRA real time salinity sites' %
@@ -242,7 +250,7 @@ def _extract_headers_for_next_request(request):
         if tag_dict.get('value', None) == 'tabular':
             #
             continue
-        #some tags don't have a value and are used w/ JS to toggle a set of checkboxes
+        # some tags don't have a value and are used w/ JS to toggle a set of checkboxes
         payload[tag_dict['name']] = tag_dict.get('value')
     return payload
 
@@ -281,7 +289,7 @@ def _make_next_request(url, previous_request, data):
 
 
 def _parse_val(val):
-    #the &nsbp translates to the following unicode
+    # the &nsbp translates to the following unicode
     if val == u'\xa0':
         return None
     else:

--- a/ulmo/nasa/daymet/core.py
+++ b/ulmo/nasa/daymet/core.py
@@ -1,12 +1,11 @@
 """
     ulmo.nasa.daymet.core
-    ~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~
 
     This module provides direct access to `NASA EARTHDATA ORNL DAAC 
     Daymet`_ web services.
 
-
-    .. .. _NASA EARTHDATA ORNL DAAC Daymet: https://daymet.ornl.gov/dataaccess.html
+    .. _NASA EARTHDATA ORNL DAAC Daymet: https://daymet.ornl.gov/dataaccess.html
 
 """
 from future import standard_library
@@ -24,13 +23,13 @@ import pandas as pd
 
 from ulmo import util
 
-VARIABLES = {"tmax":"maximum temperature",
-            "tmin":"minimum temperature",
-            "srad":"shortwave radiation",
-            "vp":"vapor pressure",
-            "swe":"snow-water equivalent",
-            "prcp":"precipitation",
-            "dayl":"daylength"}
+VARIABLES = {"tmax": "maximum temperature",
+            "tmin": "minimum temperature",
+            "srad": "shortwave radiation",
+            "vp": "vapor pressure",
+            "swe": "snow-water equivalent",
+            "prcp": "precipitation",
+            "dayl": "daylength"}
 MIN_YEAR = 1980
 MAX_Year = int(time.strftime("%Y"))-1
 MIN_LAT = 14.5
@@ -47,6 +46,7 @@ logging.basicConfig(format=LOG_FORMAT)
 log = logging.getLogger(__name__)
 log.setLevel(logging.INFO)
 
+
 def get_variables():
     """retrieve a list of variables available
 
@@ -56,16 +56,16 @@ def get_variables():
 
     Returns
     -------
-        dictionary of variables with variable abreviations as keys 
+        dictionary of variables with variable abbreviations as keys
         and description as values
     """
     return VARIABLES
+
 
 def get_daymet_singlepixel(latitude, longitude, 
                            variables=['tmax', 'tmin', 'prcp'], years=None,
                            as_dataframe=True):
     """Fetches a time series of climate variables from the DAYMET single pixel extraction
-
 
     Parameters
     ----------
@@ -73,17 +73,16 @@ def get_daymet_singlepixel(latitude, longitude,
         The latitude (WGS84), value between 52.0 and 14.5.
     longitude: float
         The longitude (WGS84), value between -131.0 and -53.0.
-    variables : List of str
-        Daymet parameters to fetch. 
+    variables : list of str
+        Daymet parameters to fetch. default = ['tmax', 'tmin', 'prcp'].
         Available options:
-            ``tmax`` - maximum temperature
-            ``tmin`` - minimum temperature
-            ``srad`` - shortwave radiation
-            ``vp`` - vapor pressure
-            ``swe`` - snow-water equivalent
-            ``prcp`` - precipitation
-            ``dayl`` - daylength
-        default = ['tmax', 'tmin', 'prcp']
+            * 'tmax': maximum temperature
+            * 'tmin': minimum temperature
+            * 'srad': shortwave radiation
+            * 'vp': vapor pressure
+            * 'swe': snow-water equivalent
+            * 'prcp': precipitation;
+            * 'dayl' : daylength.
     years: list of int
         List of years to return. 
         Daymet version 2 available 1980 to the latest full calendar year.
@@ -92,11 +91,11 @@ def get_daymet_singlepixel(latitude, longitude,
         if ``True`` return pandas dataframe
         if ``False`` return open file with contents in csv format
 
-    
     Returns
     -------
     single_pixel_timeseries : pandas dataframe or csv filename
     """
+
     _check_coordinates(latitude, longitude)
     _check_variables(variables)
     if not years is None:
@@ -123,6 +122,7 @@ def get_daymet_singlepixel(latitude, longitude,
                 results[key] = dict(zip(df[key].index.format(), df[key]))
         return results
 
+
 def _check_variables(variables):
     """make sure all variables are in list
     """
@@ -132,6 +132,7 @@ def _check_variables(variables):
         raise ValueError("the variable(s) provided ('{}') not\none of available options: '{}'".format(
             "', '".join(bad_variables), str(VARIABLES.keys())[2:-2]))
 
+
 def _check_years(years):
     """make sure all years are in available year range
     """
@@ -139,6 +140,7 @@ def _check_years(years):
     if bad_years:
         raise ValueError("the year(s) provided ({}) \nnot in available timerange ({}-{})".format(
             ", ".join(bad_years), MIN_YEAR, MAX_Year))
+
 
 def _check_coordinates(lat, lon):
     """make sure the passed coordinates are in the available data range
@@ -153,6 +155,7 @@ def _check_coordinates(lat, lon):
         err_msg += "\n\tLongitude = [{} - {}]".format(MIN_LON, MAX_LON)
         raise ValueError(err_msg)
 
+
 def _as_str(arg):
     """if arg is a list, convert to comma delimited string
     """
@@ -160,6 +163,7 @@ def _as_str(arg):
         return arg
     else:
         return ','.join([str(a) for a in arg])
+
 
 def _get_service_url(url_params):
     """return formatted url

--- a/ulmo/ncdc/cirs/core.py
+++ b/ulmo/ncdc/cirs/core.py
@@ -46,25 +46,25 @@ def get_data(elements=None, by_state=False, location_names='abbr', as_dataframe=
 
     Parameters
     ----------
-    elements : ``None`, str or list
+    elements : ``None``, str or list
         The element(s) for which to get data for. If ``None`` (default), then
         all elements are used. An individual element is a string, but a list or
         tuple of them can be used to specify a set of elements.  Elements are:
-          * 'cddc': Cooling Degree Days
-          * 'hddc': Heating Degree Days
-          * 'pcpn': Precipitation
-          * 'pdsi': Palmer Drought Severity Index
-          * 'phdi': Palmer Hydrological Drought Index
-          * 'pmdi': Modified Palmer Drought Severity Index
-          * 'sp01': 1-month Standardized Precipitation Index
-          * 'sp02': 2-month Standardized Precipitation Index
-          * 'sp03': 3-month Standardized Precipitation Index
-          * 'sp06': 6-month Standardized Precipitation Index
-          * 'sp09': 9-month Standardized Precipitation Index
-          * 'sp12': 12-month Standardized Precipitation Index
-          * 'sp24': 24-month Standardized Precipitation Index
-          * 'tmpc': Temperature
-          * 'zndx': ZNDX
+            * 'cddc': Cooling Degree Days
+            * 'hddc': Heating Degree Days
+            * 'pcpn': Precipitation
+            * 'pdsi': Palmer Drought Severity Index
+            * 'phdi': Palmer Hydrological Drought Index
+            * 'pmdi': Modified Palmer Drought Severity Index
+            * 'sp01': 1-month Standardized Precipitation Index
+            * 'sp02': 2-month Standardized Precipitation Index
+            * 'sp03': 3-month Standardized Precipitation Index
+            * 'sp06': 6-month Standardized Precipitation Index
+            * 'sp09': 9-month Standardized Precipitation Index
+            * 'sp12': 12-month Standardized Precipitation Index
+            * 'sp24': 24-month Standardized Precipitation Index
+            * 'tmpc': Temperature
+            * 'zndx': ZNDX
     by_state : bool
         If False (default), divisional data will be retrieved. If True, then
         regional data will be retrieved.
@@ -86,7 +86,6 @@ def get_data(elements=None, by_state=False, location_names='abbr', as_dataframe=
         the web. If a file-like object or a file path string, then the file will
         be used to read data from. This is intended to be used for reading in
         previously-downloaded versions of the dataset.
-
 
     Returns
     -------
@@ -202,15 +201,15 @@ def _parse_values(file_handle, by_state, location_names, element):
     if by_state:
         id_columns = [
             ('location_code', 0, 3, None),
-            #('division', 3, 3, None), # ignored in state files
-            #('element', 4, 6, None),  # element is redundant
+            # ('division', 3, 3, None), # ignored in state files
+            # ('element', 4, 6, None),  # element is redundant
             ('year', 6, 10, None),
         ]
     else:
         id_columns = [
             ('location_code', 0, 2, None),
             ('division', 2, 4, None),
-            #('element', 4, 6, None),  # element is redundant
+            # ('element', 4, 6, None),  # element is redundant
             ('year', 6, 10, None),
         ]
 
@@ -264,10 +263,10 @@ def _resolve_location_names(df, location_names, by_state):
 
 def _states_regions_dataframe():
     """returns a dataframe indexed by state/region code with columns for the
-    name and abbrevitation (abbr) to use
+    name and abbreviation (abbr) to use
     """
     STATES_REGIONS = {
-        # code: (full name, abbrevation)
+        # code: (full name, abbreviation)
         1: ("Alabama", "AL"),
         2: ("Arizona", "AZ"),
         3: ("Arkansas", "AR"),

--- a/ulmo/usgs/ned/__init__.py
+++ b/ulmo/usgs/ned/__init__.py
@@ -1,6 +1,5 @@
 """
-    `National Elevation Dataset`_ services (Raster)
-
+    `National Elevation Dataset (NED)`_ services (Raster)
 
     .. _National Elevation Dataset (NED): http://ned.usgs.gov
 """

--- a/ulmo/usgs/nwis/__init__.py
+++ b/ulmo/usgs/nwis/__init__.py
@@ -7,9 +7,7 @@
 from __future__ import absolute_import
 
 from . import core
-
 from .core import (get_sites, get_site_data)
-
 from ulmo import util
 
 try:

--- a/ulmo/usgs/nwis/core.py
+++ b/ulmo/usgs/nwis/core.py
@@ -35,65 +35,66 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.INFO)
 
 
-def get_sites(sites=None, state_code=None, huc=None, bounding_box=None, 
-        county_code=None, parameter_code=None, site_type=None, service=None, 
-        input_file=None, **kwargs):
-    """Fetches site information from USGS services. See the `USGS Site Service`_
-    documentation for a detailed description of options. For convenience, major
-    options have been included with pythonic names. Options that are not listed 
+def get_sites(service=None, input_file=None,  sites=None, state_code=None,
+              huc=None, bounding_box=None, county_code=None, parameter_code=None,
+              site_type=None, **kwargs):
+    """Fetches site information from USGS services.
+    See the `USGS Site Service`_ documentation for a detailed description of options.
+    For convenience, major options have been included with pythonic names.
+    At least one major filter must be specified. Options that are not listed
     below may be provided as extra kwargs (i.e. keyword='argument') and will be 
     passed along with the web services request. These extra keywords must match 
     the USGS names exactly. The `USGS Site Service`_ website describes available
     keyword names and argument formats. 
 
-    .. USGS Site Service:http://waterservices.usgs.gov/rest/Site-Service.html
+    .. _USGS Site Service: http://waterservices.usgs.gov/rest/Site-Service.html
 
     .. note::
         Only the options listed below have been tested and you may have mixed 
         results retrieving data with extra options specified. Currently ulmo 
-        requests and parses data in the waterml format. Some options are not 
+        requests and parses data in the WaterML 1.x format. Some options are not
         available in this format.
 
     Parameters
-    ==========
-    service : {``None``, 'instantaneous', 'iv', 'daily', 'dv'}
-        The service to use, either "instantaneous", "daily", or ``None``
-        (default).  If set to ``None``, then both services are used.  The
+    ----------
+    service : {`None`, 'instantaneous', 'iv', 'daily', 'dv'}
+        The service to use, either "instantaneous", "daily", or `None`
+        (default).  If set to `None`, then both services are used.  The
         abbreviations "iv" and "dv" can be used for "instantaneous" and "daily",
         respectively.
-    input_file: ``None``, file path or file object
-        If ``None`` (default), then the NWIS web services will be queried, but
+    input_file : `None`, file path or file object
+        If `None` (default), then the NWIS web services will be queried, but
         if a file is passed then this file will be used instead of requesting
         data from the NWIS web services.
-
-    Major Filters (At least one filter must be specified)
-    -----------------------------------------------------
-        sites : str, iterable of strings or ``None``
-            The site(s) to use; lists will be joined by a ','. 
-        state_code : str or ``None``
-            Two-letter state code used in stateCd parameter.
-        county_code : str, iterable of strings or ``None``
-            The 5 digit FIPS county code(s) used in the countyCd parameter; lists 
-            will be joined by a ','.
-        huc : str, iterable of strings or ``None``
-            The hydrologic unit code(s) to use; lists will be joined by a ','.
-        bounding_box : str, iterable of strings or ``None``
-            This bounding box used in the bBox parameter. The format is westernmost 
-            longitude, southernmost latitude, easternmost longitude, northernmost 
-            latitude; lists will be joined by a ','.
-
-    Optional Filters Provided
-    -------------------------
-        parameter_code : str, iterable of strings or ``None``
-            Parameter code(s) that will be passed as the parameterCd parameter; lists will be joined by a ','.   
-            This parameter represents the following usgs website input: Sites serving parameter codes
-        site_types : str, iterable of strings or ``None``
-            The type(s) of site used in siteType parameter; lists will be joined by a ','.
-
+    sites : str, iterable of strings or ``None``
+        A major filter. The site(s) to use; lists will be joined by a ','.
+        At least one major filter must be specified.
+    state_code : str or ``None``
+        A major filter. Two-letter state code used in ``stateCd`` parameter.
+        At least one major filter must be specified.
+    county_code : str, iterable of strings or ``None``
+        A major filter. The 5 digit FIPS county code(s) used in the countyCd parameter;
+        lists will be joined by a ','.
+        At least one major filter must be specified.
+    huc : str, iterable of strings or ``None``
+        A major filter. The hydrologic unit code(s) to use; lists will be joined by a ','.
+        At least one major filter must be specified.
+    bounding_box : str, iterable of strings or ``None``
+        A major filter. This bounding box used in the bBox parameter. The format is
+        westernmost longitude, southernmost latitude, easternmost longitude, northernmost
+        latitude; lists will be joined by a ','.
+        At least one major filter must be specified.
+    parameter_code : str, iterable of strings or ``None``
+        Optional filter. Parameter code(s) that will be passed as the ``parameterCd`` parameter;
+        lists will be joined by a ','. This parameter represents the following USGS website
+        input: Sites serving parameter codes
+    site_type : str, iterable of strings or ``None``
+        Optional filter. The type(s) of site used in ``siteType`` parameter;
+        lists will be joined by a ','.
 
     Returns
     -------
-    sites_dict : dict
+    return_sites : dict
         a python dict with site codes mapped to site information
     """
     

--- a/ulmo/usgs/nwis/hdf5.py
+++ b/ulmo/usgs/nwis/hdf5.py
@@ -19,7 +19,6 @@ from ulmo import util
 from ulmo.usgs.nwis import core
 
 
-
 # default hdf5 file path
 DEFAULT_HDF5_FILE_PATH = util.get_default_h5file_path('usgs/')
 
@@ -65,7 +64,6 @@ def get_sites(path=None, complevel=None, complib=None):
         selected. If complevel argument is set to 0 then no compression will be
         used.
 
-
     Returns
     -------
     sites_dict : dict
@@ -108,7 +106,6 @@ def get_site(site_code, path=None, complevel=None, complib=None):
         selected. If complevel argument is set to 0 then no compression will be
         used.
 
-
     Returns
     -------
     site_dict : dict
@@ -136,7 +133,7 @@ def get_site_data(site_code, agency_code=None, parameter_code=None, path=None,
     agency_code : ``None`` or str
         The agency code to get data for. This will need to be set if a site code
         is in use by multiple agencies (this is rare).
-    parameter_code : `None`, str, or list
+    parameter_code : ``None``, str, or list
         List of parameters to read. If ``None`` (default) read all parameters.
         Otherwise only read specified parameters. Parameters should be specified
         with statistic code, i.e. daily streamflow is '00060:00003'
@@ -154,9 +151,8 @@ def get_site_data(site_code, agency_code=None, parameter_code=None, path=None,
         the best available compression library available on your system will be
         selected. If complevel argument is set to 0 then no compression will be
         used.
-    start: ``None`` or string formatted date like 2014-01-01
+    start : ``None`` or string formatted date like 2014-01-01
         Filter the dataset to return only data later that the start date
-
 
     Returns
     -------


### PR DESCRIPTION
Addresses #177. Sphinx docs haven't been updated in ages.
- Updated index.rst and api.rst, including starting to reorganize api's listing for improved readability
- Started using the label "readers" for APIs
- Reorganized api.rst APIs (readers) into "Readers for Global to USA-national data" vs "Readers for USA regional (sub-national) data"
- Fixed many docstring formatting issues, to address sphinx warnings. This resulted in the exposure of docstring blocks that were not being shown (for NWIS and others) due to formatting errors
- Fixed intersphinx_mapping error in conf.py
- Updated INSTALL to current conda env creation statement
- Added sphinx-related packages to conda env, so the development environment includes everything that's needed to update and test the docs
- Added test result files to .gitignore