### PR TITLE
Dependency cleanups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,20 +10,25 @@ notifications:
 matrix:
   include:
     - os: linux
-      env: PYTHON_VERSION="3.5"
-    - os: linux
       env: PYTHON_VERSION="3.6"
     - os: linux
       env: PYTHON_VERSION="3.7"
-    - os: osx
-      osx_image: xcode9.4
-      env: PYTHON_VERSION="3.5"
+    - os: linux
+      env: PYTHON_VERSION="3.8"
+    - os: linux
+      env: PYTHON_VERSION="3.9"
     - os: osx
       osx_image: xcode9.4
       env: PYTHON_VERSION="3.6"
     - os: osx
       osx_image: xcode9.4
       env: PYTHON_VERSION="3.7"
+    - os: osx
+      osx_image: xcode9.4
+      env: PYTHON_VERSION="3.8"
+    - os: osx
+      osx_image: xcode9.4
+      env: PYTHON_VERSION="3.9"
 
 cache:
   directories:
@@ -50,8 +55,9 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
   # Create quest conda env and install deps
-  - sed $SED_OPTIONS "s/python=3/python=$PYTHON_VERSION/" conda_environment.yml
-  - conda env create -q -n test-environment -f conda_environment.yml
+  # - sed $SED_OPTIONS "s/python=3/python=$PYTHON_VERSION/" conda_environment.yml
+  # - conda env create -q -n test-environment -f conda_environment.yml
+  - conda create -n test-environment -c conda-forge python=$PYTHON_VERSION --file requirements.txt --file requirements-dev.txt
   - source activate test-environment
   - python setup.py install
   - conda list

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -8,40 +8,38 @@
 # optionally run tests:
 #   python setup.py test
 
-name: py3-ulmo
+name: ulmo
 
 channels:
     - conda-forge
     - defaults
 
 dependencies:
-    - python>=3.4
-    - pip
+    - python>=3.5
     - appdirs
     - beautifulsoup4
     - future
     - geojson
     - isodate
     - lxml
-    - mock
     - numpy
-    - pandas<1.1
+    - pandas
     - pytables
-    - pytest
     - requests
     - suds-jurko
-    - freezegun
-    - html5lib<=0.9999999
-    
+
     # Specifically for building Sphinx docs
     - numpydoc>=0.4
     - python-dateutil
     - sphinx>=1.1.3
 
     # test dependencies
-    - pytest-runner
-    - pytest-cov
+    - pip
     - coveralls
-
-    - pip:
-        - httpretty<=0.8.10
+    - freezegun
+    - html5lib
+    - mock
+    - pytest
+    - pytest-cov
+    - pytest-runner
+    - httpretty

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -24,14 +24,14 @@ dependencies:
     - lxml
     - numpy
     - pandas
-    - pytables
+#    - pytables
     - requests
     - suds-jurko
 
     # Specifically for building Sphinx docs
-    - numpydoc>=0.4
     - python-dateutil
-    - sphinx>=1.1.3
+    - numpydoc
+    - sphinx
 
     # test dependencies
     - pip

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,14 @@
+python-dateutil
+numpydoc
+sphinx
+pip
+coveralls
+freezegun
+html5lib
+httpretty
+mock
+pytest
+pytest-cov
+pytest-runner
+twine
+wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,8 @@ geojson
 isodate
 lxml
 numpy
-pandas<1.1
+pandas
 tables
 pytest
 requests
 suds-jurko
-html5lib<=0.9999999

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,5 @@ isodate
 lxml
 numpy
 pandas
-tables
-pytest
 requests
 suds-jurko

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
     description='clean, simple and fast access to public hydrology and climatology data',
     long_description=long_description,
     url='https://github.com/ulmo-dev/ulmo/',
-    keywords='his pyhis ulmo water waterml cuahsi wateroneflow usgs ned',
+    keywords='his ulmo water waterml cuahsi wateroneflow usgs ned',
     packages=find_packages(),
     platforms='any',
     install_requires=required,
@@ -92,6 +92,8 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     tests_require=[
@@ -99,7 +101,7 @@ setup(
         'freezegun',
         'pytest',
         'httpretty',
-        'html5lib<=0.9999999',
+        'html5lib',
     ],
     cmdclass={'test': PyTest},
 )

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -7,7 +7,7 @@ import re
 import shutil
 import tempfile
 
-from httpretty import HTTPretty
+import httpretty as httpretty
 import mock
 
 
@@ -74,7 +74,7 @@ def mocked_urls(url_files, methods=None, force=False):
         if isinstance(url_files, basestring):
             url_files = {'.*': url_files}
 
-        HTTPretty.enable()
+        httpretty.enable()
         for url_match, url_file in url_files.items():
             if not isinstance(url_match, basestring) and len(url_match) == 2:
                 url_match, methods = url_match
@@ -89,11 +89,11 @@ def mocked_urls(url_files, methods=None, force=False):
                 methods = ['GET', 'POST', 'HEAD']
 
             for method in methods:
-                request_class = getattr(HTTPretty, method)
-                HTTPretty.register_uri(request_class, url_re, match_querystring=True, body=callback)
+                request_class = getattr(httpretty, method)
+                httpretty.register_uri(request_class, url_re, match_querystring=True, body=callback)
         yield
-        HTTPretty.disable()
-        HTTPretty.reset()
+        httpretty.disable()
+        httpretty.reset()
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
- Now supports building and testing on Py 3.7, 3.8, 3.9
- Removed outdated version pinnings that were implicitly clamping Python builds with `conda_environment.yml` to 3.6 o
- Separated dev build (adding new `requirements-dev.txt`) from non-dev build (`requirements.txt`). `conda_environment.yml` is now deprecated
- Removed `pytables` dependency (no longer actively used)
- Updated `.travis.yml` too the new conda env create statement
