### PR TITLE
Fine tune CI and remove travis and appveyor badges

### DIFF
--- a/.github/workflows/default-tests.yml
+++ b/.github/workflows/default-tests.yml
@@ -13,7 +13,7 @@ jobs:
         python-version: ["3.6", "3.7", "3.8", "3.9"]
         # Just ubuntu, for now
         # os: [windows-latest, ubuntu-latest, macos-latest]
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
       fail-fast: false
 
     steps:
@@ -43,4 +43,4 @@ jobs:
       shell: bash -l {0}
       run: |
         source activate TEST
-        pytest -s -rxs -vv -k "not lcra"
+        pytest -s -rxs -vv -k "not lcra and not cpc_drought and not usace_rivergages and not usgs_ned"

--- a/README.rst
+++ b/README.rst
@@ -7,12 +7,6 @@ ulmo
 Project Status
 --------------
 
-.. image:: https://secure.travis-ci.org/ulmo-dev/ulmo.png?branch=master
-        :target: https://travis-ci.org/ulmo-dev/ulmo
-
-.. image:: https://ci.appveyor.com/api/projects/status/mqo6rl0f2ocngxcu/branch/master?svg=true
-        :target: https://ci.appveyor.com/project/dharhas/ulmo/branch/master
-
 .. image:: https://coveralls.io/repos/ulmo-dev/ulmo/badge.svg?branch=master&service=github
         :target: https://coveralls.io/github/ulmo-dev/ulmo?branch=master
 

--- a/test/usgs_nwis_test.py
+++ b/test/usgs_nwis_test.py
@@ -129,5 +129,4 @@ def test_get_site_data_multiple_methods():
     with test_util.mocked_urls(site_data_file):
         site_data = ulmo.usgs.nwis.get_site_data(site_code, methods={'62614': 'all', '45592': 'all'})
         assert len(site_data['00054:00003']['values']) == 1
-        print(site_data.keys())
         assert len(site_data.keys()) == 13


### PR DESCRIPTION
- Run CI only on Ubuntu and exclude known failing tests
- Remove travis and appveyor badges from README