### PR TITLE
Skip bad lines in CDEC get_stations

### DIFF
--- a/test/cdec_historical_test.py
+++ b/test/cdec_historical_test.py
@@ -9,7 +9,7 @@ def test_get_stations():
     stations_file = 'cdec/historical/all_stations.csv'
     with test_util.mocked_urls(stations_file):
         stations = ulmo.cdec.historical.get_stations()
-    assert 2000 < len(stations)
+    assert 1900 < len(stations)
     assert u'PRA' in stations.index
 
 

--- a/test/ghcn_daily_test.py
+++ b/test/ghcn_daily_test.py
@@ -10,12 +10,12 @@ import test_util
 test_stations = [
     {
         'country': 'US',
-        'elevation': 286.5,
+        'elevation': 325.8,
         'gsn_flag': 'GSN',
         'hcn_flag': 'HCN',
         'id': 'USW00003870',
-        'latitude': 34.8831,
-        'longitude': -82.2203,
+        'latitude': 34.8833,
+        'longitude': -82.2197,
         'name': 'GREER',
         'network': 'W',
         'network_id': '00003870',

--- a/ulmo/cdec/historical/core.py
+++ b/ulmo/cdec/historical/core.py
@@ -74,9 +74,9 @@ def get_stations():
         # I haven't found a better list of stations, seems pretty janky
         # to just have them in a file, and not sure if/when it is updated.
     url = 'http://cdec.water.ca.gov/misc/all_stations.csv'
-        # the csv is malformed, so some rows think there are 7 fields
-    col_names = ['id','meta_url','name','num','lat','lon','junk']
-    df = pd.read_csv(url, names=col_names, header=None, quotechar="'",index_col=0)
+        # the csv is malformed, so some rows think there are 7-8 fields
+    col_names = ['id','meta_url','name','num','lat','lon']
+    df = pd.read_csv(url, names=col_names, header=None, quotechar="'",index_col=0,on_bad_lines='skip')
 
     return df
 

--- a/ulmo/cdec/historical/core.py
+++ b/ulmo/cdec/historical/core.py
@@ -76,7 +76,7 @@ def get_stations():
     url = 'http://cdec.water.ca.gov/misc/all_stations.csv'
         # the csv is malformed, so some rows think there are 7-8 fields
     col_names = ['id','meta_url','name','num','lat','lon']
-    df = pd.read_csv(url, names=col_names, header=None, quotechar="'",index_col=0,on_bad_lines='skip')
+    df = pd.read_csv(url, names=col_names, header=None, quotechar="'",index_col=0,error_bad_lines=False)
 
     return df
 


### PR DESCRIPTION
(Warning: this has not been tested - the CI says "This workflow is awaiting approval from a maintainer".)

test/cdec_historical_test.py::get_stations [fails in pandas 1.4+](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1017573) because the file contains lines with too many fields.

(I'm not sure why this is a _new_ bug: the closest I can find is pandas-dev/pandas#22144 which isn't an exact match.)

This fix drops the invalid lines, because trying to make sense of them would produce nonsense if the extra commas aren't at the line end.