### PR TITLE
Pin pandas and numpy to older versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ future
 geojson
 isodate
 lxml
-numpy
-pandas
+numpy<1.24
+pandas<2
 python-dateutil
 requests
 suds-jurko


### PR DESCRIPTION
Substantial changes that are known to have caused problems as dependencies took place with pandas 2.0 and numpy 1.24