### PR TITLE
Set CI to run on Python 3.7, 3.8, 3.9

### DIFF
--- a/.github/workflows/default-tests.yml
+++ b/.github/workflows/default-tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9"]
         # Just ubuntu, for now
         # os: [windows-latest, ubuntu-latest, macos-latest]
         os: [ubuntu-latest]

--- a/.github/workflows/default-tests.yml
+++ b/.github/workflows/default-tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
         # Just ubuntu, for now
         # os: [windows-latest, ubuntu-latest, macos-latest]
         os: [ubuntu-latest]

--- a/.github/workflows/default-tests.yml
+++ b/.github/workflows/default-tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
         # Just ubuntu, for now
         # os: [windows-latest, ubuntu-latest, macos-latest]
         os: [ubuntu-latest]


### PR DESCRIPTION
~~To shorten total CI run time, which will make the development cycle a little leaner.~~

I could not get 3.10 to run successfully. My best guess at this point is that one of the external GH Actions I use has a problem with 3.10 but not 3.7 - 3.9, specifically with the creation and/or use of the test conda environment (see https://github.com/ulmo-dev/ulmo/pull/219#issuecomment-1574217341). Giving up and resetting the Python version matrix to 3.7, 3.8 and 3.9 only.