### PR TITLE
prefer newer unittest.mock when available

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,10 @@ import sys, os
 
 # HACKS: pytables is a difficult dependency to build, so just mock it when
 # generating docs - this makes sure the docs build fully for ulmo.readthedocs.org
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 sys.modules['tables'] = mock.MagicMock()
 sys.modules['tables.scripts'] = mock.MagicMock()
 


### PR DESCRIPTION
mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards.

https://github.com/testing-cabal/mock